### PR TITLE
Send a broadcast to other users in room when a different user joins/leaves

### DIFF
--- a/server.js
+++ b/server.js
@@ -106,7 +106,8 @@ io.on('connection', socket => {
     // })
 
 
-    socket.emit('chat message', `* Joined ${room} room *`)
+    socket.emit('chat message', `* You joined ${room} room *`)
+    socket.to(desiredRoom).emit(`chat message`, `* A user has joined ${room} room *` )
 
     socket.on('chat message', msg => {
       io.emit('chat message', msg)
@@ -123,8 +124,10 @@ io.on('connection', socket => {
     socket.leave(room)
     // socket.emit('chat message', `* Left ${room} room *`)
 
+    // tells 
     socket.to(room).emit(`chat message`, `* A user has left ${room} room *` )
-    socket.emit('chat message', `* Left ${room} room *`)
+    // tells current user that they have left the room
+    socket.emit('chat message', `* You left ${room} room *`)
   })
 
   // socket.on('chat message', msg => {

--- a/server.js
+++ b/server.js
@@ -121,7 +121,10 @@ io.on('connection', socket => {
 
   socket.on('leave', async room => {
     socket.leave(room)
-    socket.emit('chat message', `Left ${room} room`)
+    // socket.emit('chat message', `* Left ${room} room *`)
+
+    socket.to(room).emit(`chat message`, `* A user has left ${room} room *` )
+    socket.emit('chat message', `* Left ${room} room *`)
   })
 
   // socket.on('chat message', msg => {


### PR DESCRIPTION
### Overview
This pull request sends a broadcast to other users in a room when a different user joins or leaves, enhancing real-time communication and interaction within the application.

### Features Added
- Users receive notifications when other users join or leave the room.
- Maintains context by informing all members of the current state of the room.
- Improves overall user experience by ensuring all participants are aware of changes in room occupancy.

### Implementation Details
- Added socket broadcasts to notify users in a room when someone joins or leaves.
- Implemented logic to emit a message to the room when a user has exited, ensuring all members are updated accordingly.

### Testing
- Conducted manual testing to confirm that users receive appropriate notifications when others join or leave the room.

### Future Work
- Develop unit tests with Jest to validate the functionality of the new broadcast feature.
- Explore additional enhancements to improve user engagement and interaction within rooms.
- Add a room occupancy counter

### Related Issues
- n/a

### Commits in this PR
- socket broadcasts to other users in room when a user joins/leaves
- feat: emit message to room when a user has left room
